### PR TITLE
Fixes in viewBinding module, base classes and extensions to substitute databinding module

### DIFF
--- a/application/common/extensions/android-util/build.gradle.kts
+++ b/application/common/extensions/android-util/build.gradle.kts
@@ -12,5 +12,7 @@ androidUtil(
         androidx.paging,
         google.material,
         io.coil
+    ) + deps(
+        target(":common:placeholder:res")
     )
 )

--- a/application/common/extensions/android-util/src/main/java/com/stepango/blockme/common/extensions/android/util/ImageViewExtensions.kt
+++ b/application/common/extensions/android-util/src/main/java/com/stepango/blockme/common/extensions/android/util/ImageViewExtensions.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2023 tinkoff.ru
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.stepango.blockme.common.extensions.android.util
+
+import android.graphics.Color
+import android.graphics.drawable.ColorDrawable
+import android.widget.ImageView
+import androidx.annotation.DrawableRes
+import androidx.core.content.ContextCompat
+import coil.load
+import kotlin.random.Random
+
+fun ImageView.loadImage(url: String?, @DrawableRes placeholderId: Int? = null) {
+    load(url) {
+        crossfade(true)
+        placeholder(placeholderId?.let {
+            ContextCompat.getDrawable(context, it)
+        } ?: run {
+            val placeholdersColors = resources.getStringArray(R.array.placeholders)
+            val placeholderColor = placeholdersColors[Random.nextInt(placeholdersColors.size)]
+            ColorDrawable(Color.parseColor(placeholderColor))
+        })
+    }
+}

--- a/application/core/mvvm/library/src/main/java/com/stepango/blockme/core/mvvm/library/ui/BaseViewHolder.kt
+++ b/application/core/mvvm/library/src/main/java/com/stepango/blockme/core/mvvm/library/ui/BaseViewHolder.kt
@@ -16,9 +16,9 @@
 
 package com.stepango.blockme.core.mvvm.library.ui
 
-import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.RecyclerView
+import androidx.viewbinding.ViewBinding
 
-abstract class BaseViewHolder<T : ViewDataBinding>(
+abstract class BaseViewHolder<T : ViewBinding>(
     val binding: T
 ) : RecyclerView.ViewHolder(binding.root)

--- a/plugins/android/src/main/java/viewBinding.kt
+++ b/plugins/android/src/main/java/viewBinding.kt
@@ -5,6 +5,7 @@ import tools.forma.android.feature.applyFeatures
 import tools.forma.android.feature.kotlinAndroidFeatureDefinition
 import tools.forma.android.owner.NoOwner
 import tools.forma.android.owner.Owner
+import tools.forma.android.target.ApiTargetTemplate
 import tools.forma.android.target.LibraryTargetTemplate
 import tools.forma.android.target.ResourcesTargetTemplate
 import tools.forma.android.target.ViewBindingTargetTemplate
@@ -49,6 +50,7 @@ fun Project.viewBinding(
     )
     applyDependencies(
         validator = validator(
+            ApiTargetTemplate,
             WidgetTargetTemplate,
             ResourcesTargetTemplate,
             LibraryTargetTemplate


### PR DESCRIPTION
- Fix generic type for BaseViewHolder
- Add dependency on :common:placeholder:res module in android-util
- Add ImageViewExtensions file as a copy of ImageViewBindings extension method but without BindingAdapter annotation